### PR TITLE
bump to 1.19.3 (suggestion: consider merging to DEV BRANCH) | 适配 1.19.3 （请考虑合并到 dev 分支）

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.12-SNAPSHOT'
+	id 'fabric-loom' version '1.1-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,8 @@ dependencies {
 
 	// PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
 	// You may need to force-disable transitiveness on them.
-	modImplementation "com.terraformersmc:modmenu:4.0.6"
-	modApi("me.shedaniel.cloth:cloth-config-fabric:8.2.88") {
+	modImplementation "com.terraformersmc:modmenu:5.0.2"
+	modApi("me.shedaniel.cloth:cloth-config-fabric:9.0.94") {
 		exclude(group: "net.fabricmc.fabric-api")
 	}
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,13 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://fabricmc.net/versions.html
-minecraft_version=1.19.2
-yarn_mappings=1.19.2+build.10
-loader_version=0.14.9
+minecraft_version=1.19.3
+yarn_mappings=1.19.3+build.5
+loader_version=0.14.13
 
 # Mod Properties
-mod_version = 1.2.3
+mod_version = 1.2.4
 maven_group = com.innky
 archives_base_name = majobroom
 #Fabric api
-fabric_version=0.60.0+1.19.2
+fabric_version=0.73.2+1.19.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx1G
 # check these on https://fabricmc.net/versions.html
 minecraft_version=1.19.3
 yarn_mappings=1.19.3+build.5
-loader_version=0.14.13
+loader_version=0.14.14
 
 # Mod Properties
 mod_version = 1.2.4

--- a/src/main/java/net/fabricmc/majobroom/MajoBroom.java
+++ b/src/main/java/net/fabricmc/majobroom/MajoBroom.java
@@ -1,9 +1,11 @@
 package net.fabricmc.majobroom;
 
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.client.itemgroup.FabricItemGroupBuilder;
+import net.fabricmc.fabric.api.itemgroup.v1.FabricItemGroup;
+import net.fabricmc.fabric.api.itemgroup.v1.FabricItemGroupEntries;
+import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
 import net.fabricmc.fabric.api.object.builder.v1.entity.FabricEntityTypeBuilder;
-import net.fabricmc.fabric.impl.item.group.FabricCreativeGuiComponents;
+import net.fabricmc.fabric.impl.client.itemgroup.FabricCreativeGuiComponents;
 import net.fabricmc.majobroom.armors.ArmorFabric;
 import net.fabricmc.majobroom.armors.BaseArmor;
 import net.fabricmc.majobroom.config.MajoBroomConfig;
@@ -19,23 +21,40 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.Registry;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
+
 
 public class MajoBroom implements ModInitializer {
 	public static final String MODID = "majobroom";
-	public static final ItemGroup majoGroup = FabricItemGroupBuilder.build(new Identifier("majobroom", "majo_group"), () -> new ItemStack(MajoBroom.broomItem));
+	public static final ItemGroup majoGroup = FabricItemGroup.builder(new Identifier(MODID, "majo_group"))
+		.icon(() -> new ItemStack(MajoBroom.broomItem)).build();
+	
 
 	//盔甲部分
 	public static final ArmorMaterial FABRIC_ARMOR = new ArmorFabric();
-	public static final Item broomItem = new BroomItem(new Item.Settings().group(MajoBroom.majoGroup).maxCount(1));
+	public static final Item broomItem = new BroomItem(new Item.Settings().maxCount(1));
+//	group(MajoBroom.majoGroup)
 	public static final Item majoCloth = new BaseArmor(FABRIC_ARMOR, EquipmentSlot.CHEST);
 //	public static final Item majoStocking = new BaseArmor(FABRIC_ARMOR, EquipmentSlot.FEET);
 	public static final Item majoHat = new BaseArmor(FABRIC_ARMOR, EquipmentSlot.HEAD);
 
 
+	//ItemGroup
+	static {
+		ItemGroupEvents.modifyEntriesEvent(majoGroup).register(MajoBroom::setItemGroup);
+	}
+	
+	protected static void setItemGroup(FabricItemGroupEntries entries) {
+		entries.add(broomItem);
+		entries.add(majoHat);
+		entries.add(majoCloth);
+		//entries.add(majoStocking);
+	}
+
 	//实体
 	public static final EntityType<BroomEntity> BROOM_ENTITY_ENTITY_TYPE = Registry.register(
-			Registry.ENTITY_TYPE,
+			Registries.ENTITY_TYPE,
 			new Identifier(MODID, "majo_broom"),
 			FabricEntityTypeBuilder.create(SpawnGroup.CREATURE, BroomEntity::new).dimensions(EntityDimensions.fixed(0.75f, 0.75f)).build()
 	);
@@ -43,14 +62,13 @@ public class MajoBroom implements ModInitializer {
 	@Override
 	public void onInitialize() {
 
-		Registry.register(Registry.ITEM, new Identifier(MODID, "broom_item"), broomItem);
-		Registry.register(Registry.ITEM, new Identifier(MODID, "majo_cloth"), majoCloth);
-//		Registry.register(Registry.ITEM, new Identifier(MODID, "stocking"), majoStocking);
-		Registry.register(Registry.ITEM, new Identifier(MODID, "majo_hat"), majoHat);
+		Registry.register(Registries.ITEM, new Identifier(MODID, "broom_item"), broomItem);
+		Registry.register(Registries.ITEM, new Identifier(MODID, "majo_cloth"), majoCloth);
+//		Registry.register(Registries.ITEM, new Identifier(MODID, "stocking"), majoStocking);
+		Registry.register(Registries.ITEM, new Identifier(MODID, "majo_hat"), majoHat);
 //		FabricDefaultAttributeRegistry.register(CUBE, CubeEntity);
-//		Registry.register(Registry.ITEM, new Identifier(MODID, "fabric_helmet"), new BaseArmor(FABRIC_ARMOR, EquipmentSlot.HEAD));
+//		Registry.register(Registries.ITEM, new Identifier(MODID, "fabric_helmet"), new BaseArmor(FABRIC_ARMOR, EquipmentSlot.HEAD));
 		MajoBroomConfig.getInstance();
-
 
 	}
 

--- a/src/main/java/net/fabricmc/majobroom/armors/BaseArmor.java
+++ b/src/main/java/net/fabricmc/majobroom/armors/BaseArmor.java
@@ -10,7 +10,7 @@ import net.minecraft.nbt.NbtCompound;
 public class BaseArmor extends DyeableArmorItem implements DyeableItem {
 
     public BaseArmor(ArmorMaterial material, EquipmentSlot slot) {
-        super(material, slot, new Item.Settings().group(MajoBroom.majoGroup));
+        super(material, slot, new Item.Settings());
         DispenserBlock.registerBehavior(this,ArmorItem.DISPENSER_BEHAVIOR);//发射器穿装备
     }
 

--- a/src/main/java/net/fabricmc/majobroom/client/render/feature/MajoClothFeatureRenderer.java
+++ b/src/main/java/net/fabricmc/majobroom/client/render/feature/MajoClothFeatureRenderer.java
@@ -66,6 +66,7 @@ public class MajoClothFeatureRenderer<T extends LivingEntity, M extends BipedEnt
         if (itemStack.getItem() instanceof BaseArmor) {
             ArmorItem armorItem = (ArmorItem)itemStack.getItem();
             if (armorItem.getSlotType() == armorSlot) {
+                this.getContextModel().copyBipedStateTo(model);
                 //this.getContextModel().setAttributes(model);
                 this.setVisible(model, armorSlot);
                 boolean bl = this.usesSecondLayer(armorSlot);

--- a/src/main/java/net/fabricmc/majobroom/client/render/feature/MajoClothFeatureRenderer.java
+++ b/src/main/java/net/fabricmc/majobroom/client/render/feature/MajoClothFeatureRenderer.java
@@ -66,7 +66,7 @@ public class MajoClothFeatureRenderer<T extends LivingEntity, M extends BipedEnt
         if (itemStack.getItem() instanceof BaseArmor) {
             ArmorItem armorItem = (ArmorItem)itemStack.getItem();
             if (armorItem.getSlotType() == armorSlot) {
-                this.getContextModel().setAttributes(model);
+                //this.getContextModel().setAttributes(model);
                 this.setVisible(model, armorSlot);
                 boolean bl = this.usesSecondLayer(armorSlot);
                 int i = ((DyeableArmorItem)armorItem).getColor(itemStack);

--- a/src/main/java/net/fabricmc/majobroom/entity/BroomEntityRenderer.java
+++ b/src/main/java/net/fabricmc/majobroom/entity/BroomEntityRenderer.java
@@ -12,7 +12,7 @@ import net.minecraft.client.render.entity.EntityRenderer;
 import net.minecraft.client.render.entity.EntityRendererFactory;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.math.Vec3f;
+import net.minecraft.util.math.RotationAxis;
 
 @Environment(EnvType.CLIENT)
 public class BroomEntityRenderer extends EntityRenderer<BroomEntity> {
@@ -30,8 +30,8 @@ public class BroomEntityRenderer extends EntityRenderer<BroomEntity> {
         float floating_value = entity.getFloatingValue(tickDelta);
         matrices.push();
         matrices.translate(0,floating_value,0);
-        matrices.multiply(Vec3f.POSITIVE_X.getDegreesQuaternion(p));
-        matrices.multiply(Vec3f.POSITIVE_Y.getDegreesQuaternion(90-y));
+        matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(p));
+        matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(90-y));
         broomModel.render(matrices,vertexConsumer,light, OverlayTexture.DEFAULT_UV, 1.0F, 1.0F, 1.0F, 1.0F);
         matrices.pop();
         super.render(entity, yaw, tickDelta, matrices, vertexConsumers, light);

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -42,7 +42,7 @@
   "depends": {
     "fabricloader": ">=0.12.0",
     "fabric": "*",
-    "minecraft": "1.19.2",
+    "minecraft": "1.19.3",
     "java": ">=17",
     "cloth-config2":">=8.2.88"
   },

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "majobroom",
-  "version": "1.2.2",
+  "version": "1.2.4",
 
   "name": "Majo's Broom",
   "description": "A flying broom!",
@@ -44,10 +44,10 @@
     "fabric": "*",
     "minecraft": "1.19.3",
     "java": ">=17",
-    "cloth-config2":">=8.2.88"
+    "cloth-config2":">=9.0.92"
   },
   "suggests": {
-    "modmenu": ">=4.0.6"
+    "modmenu": ">=5.0.0"
   },
   "custom": {
     "modmenu": {


### PR DESCRIPTION
修改了一些代码，以适配1.19.3。

据我测试与Sodium等优化mod没有什么冲突，不过我注释了一条不明语句(src/main/java/net/fabricmc/majobroom/client/render/feature/MajoClothFeatureRenderer.java:69)，不清楚该语句的效果，还请检查一下，谢谢！

tips: 我的版本中，披风的飘动方向不符合物理特性，飘反了。向右转的时候披风本应向左移动，反向同理。结果是反的。前后没有问题。

下图为1.19.3中，向右转披风的效果。
![图片](https://user-images.githubusercontent.com/36123081/216826643-7e00f3c4-2095-4ac7-9f7a-2d7382c41499.png)
